### PR TITLE
Use express-extend to extend Express apps

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,20 +1,15 @@
 'use strict';
 
-exports.extend = extendApp;
+var extendExpress = require('express-extend');
+
+exports.extend = extendExpress('@annotations', exports, extendApp);
 
 function extendApp(app) {
-    if (app['@annotations']) { return app; }
-
-    // Brand.
-    Object.defineProperty(app, '@annotations', {value: true});
-
     // Modifies the Express `app` by adding the `annotate()` and `findAll()`
     // methods.
     app.annotations = {};
     app.annotate    = annotate;
     app.findAll     = findAll;
-
-    return app;
 }
 
 function annotate(routePath, annotations) {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "repository": {
     "type": "git",
-    "url" : "git://github.com/yahoo/express-annotations.git"
+    "url": "git://github.com/yahoo/express-annotations.git"
   },
   "bugs": {
     "url": "https://github.com/yahoo/express-annotations/issues"
@@ -39,5 +39,8 @@
     "unit": "mocha tests/unit/*.js --reporter spec",
     "lint": "jshint ./*.js* ./tests/unit/*.js"
   },
-  "license": "BSD"
+  "license": "BSD",
+  "dependencies": {
+    "express-extend": "0.0.1"
+  }
 }


### PR DESCRIPTION
I created a new package: [ericf/express-extend](https://github.com/ericf/express-extend) for applying the branding pattern to extending Express apps and this PR uses it. Let me know what you think.

/cc @caridy 
