### PR TITLE
Add `express` to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "devDependencies": {
     "chai": "1.5.x",
+    "express": "3.x",
     "istanbul": "*",
     "jshint": "*",
     "mocha": "1.8.x",


### PR DESCRIPTION
Fixes the failing Travis build in #7, since `express` isn't being installed when `npm install` is run.
