### PR TITLE
Add contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,46 @@
+Contributing Code to `express-annotations`
+----------------------------------
+
+This component follows the same contribution model used by [Mojito][], with
+more details available at [Contributing Code to Mojito][].
+
+Please be sure to sign our [CLA][] before you submit pull requests or otherwise contribute to `express-annotations`. This protects `express-annotations` developers, who rely on [express-annotations's BSD license][].
+
+[express-annotations's BSD license]: https://github.com/yahoo/express-annotations/blob/master/LICENSE
+[CLA]: http://developer.yahoo.com/cocktails/mojito/cla/
+[Mojito]: https://github.com/yahoo/mojito
+[Contributing Code to Mojito]: https://github.com/yahoo/mojito/wiki/Contributing-Code-to-Mojito
+
+Dev mode installation
+---------------------
+
+- The main source files are located under `lib/`.
+- Unit tests are located under `tests/unit/*`.
+- Examples are located under `examples/`.
+
+To install the dependencies:
+
+    npm install
+
+To run the unit tests (with coverage by default):
+
+    npm test
+
+To lint the app lib folder:
+
+    npm run lint
+    
+Release checklist
+-----------------
+
+* Verify that [HISTORY.md] is updated
+* Verify that [README.md] is updated
+* Bump the version in [package.json]
+* Commit to master
+* Push to npm using `npm publish`
+* Create a [new release] entry including the tag for the new version, being sure to document any deprecations
+
+[HISTORY.md]: https://github.com/yahoo/express-annotations/blob/master/HISTORY.md
+[README.md]: https://github.com/yahoo/express-annotations/blob/master/README.md
+[package.json]: https://github.com/yahoo/express-annotations/blob/master/package.json
+[new release]: https://github.com/yahoo/express-annotations/releases/new


### PR DESCRIPTION
Finishing up some minor last parts for open-sourcing `express-annotations` - it's a slight variation of the CONTRIBUTING guidelines found in the other Modown components.
