### PR TITLE
Fix test script to run on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,10 +37,9 @@
     "npm": ">=1.2.10"
   },
   "scripts": {
-    "test": "istanbul cover -- node_modules/.bin/_mocha tests/unit/*.js --reporter spec",
-    "unit": "mocha tests/unit/*.js --reporter spec",
-    "lint": "jshint {.,tests/unit}/*.js",
-    "pretest": "jshint {.,tests/unit}/*.js"
+    "test": "istanbul cover -- node_modules/mocha/bin/_mocha tests/unit/ --reporter spec",
+    "unit": "mocha tests/unit/ --reporter spec",
+    "lint": "jshint {.,tests/unit}/*.js"
   },
   "license": "BSD"
 }


### PR DESCRIPTION
Windows had some trouble getting to the Istanbul CLI and finding the right Mocha script. This variation of the test script should work on all platforms. Also removing failing pretest jshint.  I can get jshint to work by doing:

```
jshint lib test/unit
```

But the I'm not getting any messages from it.
