### PR TITLE
Express 4.x support

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,7 @@
     "trailing": true,  // Prohibit trailing whitespace
     "undef"   : true,  // Require all non-global variables to be declared
     "unused"  : true,  // Require all defined variables be used
+    "expr"    : true,
 
     // relaxing, over defaults
     "latedef"     : false, // Require variables/functions to be defined before being used

--- a/index.js
+++ b/index.js
@@ -110,7 +110,7 @@ function filterExpressRoutes(appAnnotations, annotations, routes) {
 }
 
 function filterLegacyExpressRoutes(appAnnotations, annotations, routes) {
-    // Routes in Express 3.x are an object keyed of 
+    // Routes in Express 3.x are an object keyed off of the HTTP method 
     return Object.keys(routes).reduce(function (map, method) {
         var matches = routes[method].filter(function (route) {
             var pathAnnotations = typeof route.path === 'string' &&

--- a/index.js
+++ b/index.js
@@ -77,32 +77,31 @@ function filterExpressRoutes(appAnnotations, annotations, routes) {
 
     return matches.reduce(function (map, match) {
         var stackRoute = match.route,
-            stack = stackRoute && stackRoute.stack;
+            stack = stackRoute && stackRoute.stack,
+            route = {
+                path  : stackRoute.path,
+                keys  : match.keys,
+                regexp: match.regexp
+            };
 
         // If this is a generic route added through `router.route()`
         // or through `router.VERB()`.
         if (stack && Array.isArray(stack)) {
             stack.map(function (stackItem) {
-                map[stackItem.method] = map[stackItem.method] || [];
+                var method = stackItem.method;
 
-                map[stackItem.method].push({
-                    path  : stackRoute.path,
-                    method: stackItem.method,
-                    keys  : match.keys,
-                    regexp: match.regexp
-                }); 
+                map[method] = map[method] || [];
+                route.method = method;
+
+                map[method].push(route); 
             });
         // If this is a route added through `router.all()`
         } else if (stack && typeof(stack) === 'function') {
             methods.map(function (method) {
                 map[method] = map[method] || [];
+                route.method = method;
 
-                map[method].push({
-                    path  : stackRoute.path,
-                    method: method,
-                    keys  : match.keys,
-                    regexp: match.regexp   
-                });
+                map[method].push(route);
             });
         }
 

--- a/index.js
+++ b/index.js
@@ -8,9 +8,9 @@ See the accompanying LICENSE file for terms.
 
 var methods = require('methods');
 
-exports.extend = extendApp;
+exports.extend = extendObject;
 
-function extendApp(object) {
+function extendObject(object) {
     if (object['@annotations']) { return object; }
 
     // Brand.
@@ -110,6 +110,7 @@ function filterExpressRoutes(appAnnotations, annotations, routes) {
 }
 
 function filterLegacyExpressRoutes(appAnnotations, annotations, routes) {
+    // Routes in Express 3.x are an object keyed of 
     return Object.keys(routes).reduce(function (map, method) {
         var matches = routes[method].filter(function (route) {
             var pathAnnotations = typeof route.path === 'string' &&

--- a/package.json
+++ b/package.json
@@ -15,11 +15,11 @@
     "routes"
   ],
   "peerDependencies": {
-    "express": "3.x"
+    "express": ">=3.x"
   },
   "devDependencies": {
     "chai": "1.5.x",
-    "express": "3.x",
+    "express": "4.x",
     "istanbul": "*",
     "jshint": "*",
     "mocha": "1.8.x",

--- a/package.json
+++ b/package.json
@@ -15,22 +15,22 @@
     "routes"
   ],
   "dependencies": {
-    "methods": "1.0.0"
+    "methods": "^1.0.0"
   },
   "peerDependencies": {
     "express": ">=3.x"
   },
   "devDependencies": {
-    "chai": "1.5.x",
+    "chai": "^1.9.1",
     "express": "4.x",
     "istanbul": "*",
     "jshint": "*",
-    "mocha": "1.8.x",
+    "mocha": "^1.20.0",
     "xunit-file": "*"
   },
   "repository": {
     "type": "git",
-    "url" : "git://github.com/yahoo/express-annotations.git"
+    "url": "git://github.com/yahoo/express-annotations.git"
   },
   "bugs": {
     "url": "https://github.com/yahoo/express-annotations/issues"

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "author": "Eric Ferraiuolo <eferraiuolo@gmail.com>",
   "homepage": "https://github.com/yahoo/express-annotations",
   "contributors": [
-    "alberto chan <imalberto@gmail.com>",
-    "Caridy Patino <caridy@gmail.com>"
+    "Alberto Chan <imalberto@gmail.com>",
+    "Caridy Patino <caridy@gmail.com>",
+    "Clarence Leung <clarle@yahoo-inc.com>"
   ],
   "main": "index.js",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "modown",
     "routes"
   ],
+  "dependencies": {
+    "methods": "1.0.0"
+  },
   "peerDependencies": {
     "express": ">=3.x"
   },

--- a/tests/unit/annotate-test.js
+++ b/tests/unit/annotate-test.js
@@ -242,11 +242,10 @@ describe('Express Annotations', function () {
                 var routes = app.findAll({ label: 'Blog Post' }),
                     route = routes.get[0];
 
-                expect(route).to.contain.keys('path', 'method', 'callbacks', 'keys', 'regexp');
+                expect(route).to.contain.keys('path', 'method', 'keys', 'regexp');
 
                 expect(route.path).to.be.a('string');
                 expect(route.method).to.be.a('string');
-                expect(route.callbacks).to.be.an('array');
                 expect(route.keys).to.be.an('array');
                 expect(route.regexp).to.be.a('regexp');
             });

--- a/tests/unit/annotate-test.js
+++ b/tests/unit/annotate-test.js
@@ -52,7 +52,7 @@ describe('Express Annotations', function () {
                 app.annotate(/^\/\/?$/i, {
                     label: 'Home'
                 });
-            }).to.throw(TypeError, 'Annotations require routePath to be a String');
+            }).to.throw(TypeError, 'Annotations require route path to be a String');
         });
 
         it('should annotate a path correctly with an annotations object', function () {


### PR DESCRIPTION
Initial drop for Express 4.x support. This includes:
- Allowing for the extension of Express 4.x Routers as well as Express 4.x apps
- Normalizing Express 4.x routes so that they return the same output as Express 3.x when calling `app.findAll()` or `router.findAll()`.

Todo:
- [ ] Tests for Express 4.x Routers.
- [ ] Update README.
